### PR TITLE
Remove nodejs, since this is not required anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,9 @@ RUN \
     cmake \
     wget \
     git \
-    nodejs npm\
     vim && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
-
-# Install typescript plugin
-RUN \
-  npm i ts-protoc-gen --global
 
 WORKDIR "/tmp/build"
 


### PR DESCRIPTION
gRPC is not used in NodeJS anymore, right?